### PR TITLE
Changed EnderIO recipe to support the new Capacitor Bank - fixes #17

### DIFF
--- a/src/main/java/powercrystals/powerconverters/crafting/mods/RecipeEnderIO.java
+++ b/src/main/java/powercrystals/powerconverters/crafting/mods/RecipeEnderIO.java
@@ -2,6 +2,7 @@ package powercrystals.powerconverters.crafting.mods;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.config.Configuration;
 import powercrystals.powerconverters.crafting.RecipeProvider;
@@ -18,13 +19,31 @@ public class RecipeEnderIO extends RecipeProvider{
         //To change body of implemented methods use File | Settings | File Templates.
         PowerSystem rf = PowerSystemManager.getInstance().getPowerSystemByName(PowerRedstoneFlux.id);
         if(rf != null) {
-            Block converterBlock = rf.block;
+            Block converterBlock = rf.block;            
+            
+            //
+            // Support both, new and old Capacitor bank
+            // (where the new is the most prefered one)
+            //
+            Item capBank = GameRegistry.findItem("EnderIO", "blockCapBank");
+            ItemStack stackCapacitorBank;
+            if(capBank != null) {
+	        	// New Style Capacitor Bank
+	            stackCapacitorBank = new ItemStack(capBank, 1, 2);	// Basic -> :1,  Normal -> :2, Vibrant -> :3
+
+    		} else {
+    			// Old Capacitor Bank
+    			stackCapacitorBank = GameRegistry.findItemStack("EnderIO", "blockCapacitorBank", 1);
+	    		
+    		}
+    		
+    		        
             GameRegistry.addRecipe(new ItemStack(converterBlock, 1, 0),
                     "G G",
                     " T ",
                     "G G",
                     'G', GameRegistry.findItem("minecraft", "gold_ingot"),
-                    'T', GameRegistry.findItemStack("EnderIO", "blockCapacitorBank", 1)
+                    'T', stackCapacitorBank
             );
         }
     }


### PR DESCRIPTION
Older enderIO versions are still supported, as the code tries to find the new CapBank first, if not found - it will use the old Capacitor Bank.

I suggest to keep this for at least 1-2 months, so noone wil be forced to upgrade eio while using the last recent power-converters version.

Maybe the recipe could be changed to allow all types of Capacitor Banks being used (basic, normal and vibrant) - at the moment it requires the Normal one.
